### PR TITLE
지도 클러스터링 리팩토링

### DIFF
--- a/Projects/Common/Sources/Clustering/ClusterManager.swift
+++ b/Projects/Common/Sources/Clustering/ClusterManager.swift
@@ -31,72 +31,59 @@ import MapKit
     }
 
     private func cluster(visibleMapRect: MKMapRect, zoomScale: Double) {
-        guard !zoomScale.isInfinite else {
-            return
-        }
+        guard !zoomScale.isInfinite else { return }
 
-        clusterAnnotations = []
         let minX = visibleMapRect.minX
         let maxX = visibleMapRect.minX + visibleMapRect.width
         let minY = visibleMapRect.minY
         let maxY = visibleMapRect.minY + visibleMapRect.height
         let cellSizePoints = Double(visibleMapRect.size.width / Double(calculateDivisionCount(for: MKZoomScale(zoomScale))))
 
-        var yCoordinate = minY
+        Task.detached {
+            var newClusters: [ClusterAnnotation] = []
+            var yCoordinate = minY
 
-        while yCoordinate < maxY {
-            var xCoordinate = minX
+            while yCoordinate < maxY {
+                var xCoordinate = minX
 
-            while xCoordinate < maxX {
-                let area = BoundingBox.init(mapRect: MKMapRect(x: xCoordinate, y: yCoordinate, width: cellSizePoints, height: cellSizePoints))
+                while xCoordinate < maxX {
+                    let area = BoundingBox(mapRect: MKMapRect(x: xCoordinate, y: yCoordinate, width: cellSizePoints, height: cellSizePoints))
 
-                Task {
-                    do {
-                        let annotations = try await self.quadTree.findAnnotations(searchInBoundingBox: area)
-                        if annotations.count > 1 {
-                            var totalX = 0.0
-                            var totalY = 0.0
-                            let totalAnnotationsCount = annotations.count
-                            var titlesSet: Set<String> = []
-                            for annotation in annotations {
-                                totalX += annotation.coordinate.latitude
-                                totalY += annotation.coordinate.longitude
-                                if let title = annotation.title {
-                                    titlesSet.insert(title)
-                                }
-                            }
+                    let annotations = self.quadTree.findAnnotations(searchInBoundingBox: area)
 
-                            let averageCoordinate = CLLocationCoordinate2D(latitude: totalX / Double(totalAnnotationsCount),
-                                                                           longitude: totalY / Double(totalAnnotationsCount))
-                            let annotationTitle = "\(totalAnnotationsCount)"
-                            let annotationTitles = Array(titlesSet)
+                    if annotations.count > 1 {
+                        var totalX = 0.0
+                        var totalY = 0.0
+                        var titlesSet: Set<String> = []
 
-                            DispatchQueue.main.async {
-                                self.clusterAnnotations.append(
-                                    ClusterAnnotation(coordinate: averageCoordinate,
-                                                     title: annotationTitle,
-                                                     titles: annotationTitles)
-                                )
-                            }
-                        } else if annotations.count == 1 {
-                            if let annotation = annotations.first, let title = annotation.title {
-                                DispatchQueue.main.async {
-                                    self.clusterAnnotations.append(
-                                        ClusterAnnotation(coordinate: annotation.coordinate,
-                                                         title: "1",
-                                                         titles: [title])
-                                    )
-                                }
-                            }
+                        for annotation in annotations {
+                            totalX += annotation.coordinate.latitude
+                            totalY += annotation.coordinate.longitude
+                            if let title = annotation.title { titlesSet.insert(title) }
+                        }
+
+                        let averageCoordinate = CLLocationCoordinate2D(latitude: totalX / Double(annotations.count),
+                                                                       longitude: totalY / Double(annotations.count))
+
+                        newClusters.append(ClusterAnnotation(coordinate: averageCoordinate,
+                                                             title: "\(annotations.count)",
+                                                             titles: Array(titlesSet)))
+
+                    } else if annotations.count == 1 {
+                        if let annotation = annotations.first, let title = annotation.title {
+                            newClusters.append(ClusterAnnotation(coordinate: annotation.coordinate,
+                                                                 title: "1",
+                                                                 titles: [title]))
                         }
                     }
-                    catch {
-                        print("find annotaions error: \(error.localizedDescription)")
-                    }
+                    xCoordinate += cellSizePoints
                 }
-                xCoordinate += cellSizePoints
+                yCoordinate += cellSizePoints
             }
-            yCoordinate += cellSizePoints
+
+            await MainActor.run {
+                self.clusterAnnotations = newClusters
+            }
         }
     }
 

--- a/Projects/Common/Sources/Clustering/QuadTree.swift
+++ b/Projects/Common/Sources/Clustering/QuadTree.swift
@@ -43,22 +43,27 @@ final class QuadTree {
         southEast = nil
     }
 
-    func insert(annotation: ClusterAnnotation) {
+    @discardableResult
+    func insert(annotation: ClusterAnnotation) -> Bool {
         guard self.boundingBox.contains(coordinate: annotation.coordinate) else {
-            return
+            return false
         }
 
         if annotations.count < QuadTree.capacity {
             annotations.append(annotation)
-        } else {
-            if northWest == nil {
-                self.subdivide()
-            }
-            northWest?.insert(annotation: annotation)
-            northEast?.insert(annotation: annotation)
-            southWest?.insert(annotation: annotation)
-            southEast?.insert(annotation: annotation)
+            return true
         }
+
+        if northWest == nil {
+            self.subdivide()
+        }
+
+        if northWest?.insert(annotation: annotation) == true { return true }
+        if northEast?.insert(annotation: annotation) == true { return true }
+        if southWest?.insert(annotation: annotation) == true { return true }
+        if southEast?.insert(annotation: annotation) == true { return true }
+
+        return false
     }
 
     func findAnnotations(searchInBoundingBox: BoundingBox) -> [ClusterAnnotation] {

--- a/Projects/Common/Sources/Clustering/QuadTree.swift
+++ b/Projects/Common/Sources/Clustering/QuadTree.swift
@@ -49,21 +49,40 @@ final class QuadTree {
             return false
         }
 
+        // 이미 분할된 노드(부모 노드)라면, 자식에게 넘김
+        if isDivided {
+            return insertIntoChildren(annotation: annotation)
+        }
+
+        // 아직 자리가 남았다면 부모가 가짐
         if annotations.count < QuadTree.capacity {
             annotations.append(annotation)
             return true
         }
 
-        if northWest == nil {
-            self.subdivide()
+        // [무한 재귀 방어] 가로 또는 세로 길이가 한계치보다 작아지면 분할 중지
+        // (완전히 동일하거나 극도로 가까운 좌표 밀집 시 Stack Overflow 방지)
+        let width = boundingBox.maxLongitude - boundingBox.minLongitude
+        let height = boundingBox.maxLatitude - boundingBox.minLatitude
+
+        if width < 0.00001 || height < 0.00001 {
+            annotations.append(annotation)
+            return true
         }
 
-        if northWest?.insert(annotation: annotation) == true { return true }
-        if northEast?.insert(annotation: annotation) == true { return true }
-        if southWest?.insert(annotation: annotation) == true { return true }
-        if southEast?.insert(annotation: annotation) == true { return true }
+        // 기존 데이터를 미리 분리
+        let oldAnnotations = annotations
+        annotations.removeAll()
 
-        return false
+        subdivide()
+
+        // 분리해둔 기존 데이터들을 자식들에게 재분배
+        for oldAnnotation in oldAnnotations {
+            insertIntoChildren(annotation: oldAnnotation)
+        }
+
+        // 이번에 새로 들어온 데이터도 자식에게 전달
+        return insertIntoChildren(annotation: annotation)
     }
 
     func findAnnotations(searchInBoundingBox: BoundingBox) -> [ClusterAnnotation] {
@@ -97,5 +116,15 @@ final class QuadTree {
         northEast = QuadTree(boundingBox: BoundingBox(minLatitude: midLatitude, maxLatitude: boundingBox.maxLatitude, minLongitude: midLongitude, maxLongitude: boundingBox.maxLongitude))
         southWest = QuadTree(boundingBox: BoundingBox(minLatitude: boundingBox.minLatitude, maxLatitude: midLatitude, minLongitude: boundingBox.minLongitude, maxLongitude: midLongitude))
         southEast = QuadTree(boundingBox: BoundingBox(minLatitude: boundingBox.minLatitude, maxLatitude: midLatitude, minLongitude: midLongitude, maxLongitude: boundingBox.maxLongitude))
+    }
+
+    // 자식 노드들에게 순서대로 삽입을 시도하는 헬퍼 메서드
+    @discardableResult
+    private func insertIntoChildren(annotation: ClusterAnnotation) -> Bool {
+        if northWest?.insert(annotation: annotation) == true { return true }
+        if northEast?.insert(annotation: annotation) == true { return true }
+        if southWest?.insert(annotation: annotation) == true { return true }
+        if southEast?.insert(annotation: annotation) == true { return true }
+        return false
     }
 }

--- a/Projects/Common/Sources/Clustering/QuadTree.swift
+++ b/Projects/Common/Sources/Clustering/QuadTree.swift
@@ -61,7 +61,7 @@ final class QuadTree {
         }
     }
 
-    func findAnnotations(searchInBoundingBox: BoundingBox) async throws -> [ClusterAnnotation] {
+    func findAnnotations(searchInBoundingBox: BoundingBox) -> [ClusterAnnotation] {
         guard searchInBoundingBox.intersects(boundingBox: boundingBox) else {
             return []
         }
@@ -74,18 +74,10 @@ final class QuadTree {
         }
 
         if isDivided {
-            async let northEastResults = northEast?.findAnnotations(searchInBoundingBox: searchInBoundingBox) ?? []
-            async let northWestResults = northWest?.findAnnotations(searchInBoundingBox: searchInBoundingBox) ?? []
-            async let southEastResults = southEast?.findAnnotations(searchInBoundingBox: searchInBoundingBox) ?? []
-            async let southWestResults = southWest?.findAnnotations(searchInBoundingBox: searchInBoundingBox) ?? []
-            do {
-                totalAnnotations.append(contentsOf: try await northEastResults)
-                totalAnnotations.append(contentsOf: try await northWestResults)
-                totalAnnotations.append(contentsOf: try await southEastResults)
-                totalAnnotations.append(contentsOf: try await southWestResults)
-            } catch {
-                throw error
-            }
+            totalAnnotations.append(contentsOf: northEast?.findAnnotations(searchInBoundingBox: searchInBoundingBox) ?? [])
+            totalAnnotations.append(contentsOf: northWest?.findAnnotations(searchInBoundingBox: searchInBoundingBox) ?? [])
+            totalAnnotations.append(contentsOf: southEast?.findAnnotations(searchInBoundingBox: searchInBoundingBox) ?? [])
+            totalAnnotations.append(contentsOf: southWest?.findAnnotations(searchInBoundingBox: searchInBoundingBox) ?? [])
         }
 
         return totalAnnotations

--- a/Projects/Siggi/Sources/Presentation/Search/SearchView.swift
+++ b/Projects/Siggi/Sources/Presentation/Search/SearchView.swift
@@ -65,16 +65,15 @@ struct SearchView: View {
                 }
                 .onChange(of: placeRecords) {
                     updateClusterAnnotations()
-                    clusterManager.clusterAnnotations(visibleMapRect: currentVisibleMapRect, zoomScale: currentZoomScale)
-                }
-                .onChange(of: locationManager.region) { oldValue, newValue in
-                    position = .region(newValue)
+                    clusterManager.clusterAnnotations(visibleMapRect: currentVisibleMapRect,
+                                                      zoomScale: currentZoomScale)
                 }
                 .onMapCameraChange { context in
                     currentVisibleMapRect = context.rect
                     let visibleMapRectWidth = currentVisibleMapRect.size.width
                     currentZoomScale = mapViewSize.width > 0 ? Double(mapViewSize.width / visibleMapRectWidth) : 1.0
-                    clusterManager.clusterAnnotations(visibleMapRect: currentVisibleMapRect, zoomScale: currentZoomScale)
+                    clusterManager.clusterAnnotations(visibleMapRect: currentVisibleMapRect,
+                                                      zoomScale: currentZoomScale)
                 }
 
                 VStack(alignment: .trailing) {
@@ -108,7 +107,10 @@ struct SearchView: View {
 
     private func updateClusterAnnotations() {
         let annotations = placeRecords.map { record in
-            ClusterAnnotation(coordinate: CLLocationCoordinate2D(latitude: record.latitude, longitude: record.longitude), title: record.name, titles: [])
+            ClusterAnnotation(coordinate: CLLocationCoordinate2D(latitude: record.latitude,
+                                                                 longitude: record.longitude),
+                              title: record.name,
+                              titles: [])
         }
         clusterManager.addAnnotations(annotations: annotations)
     }


### PR DESCRIPTION
- [X] cluster 로직 Swift Concurrency 최적화
- [X] QuadTree insert 로직 개선
- [X] 지도 카메라 제자리 복귀 현상 수정
<br/>

### cluster 로직 Swift Concurrency 최적화
- QuadTree 비동기 처리 제거: QuadTree 내부 탐색 로직(findAnnotation())은 메모리 내 단순 CPU 연산이므로, 잦은 컨텍스트 스위칭(Context Switching) 오버헤드를 막기 위해 async/await을 제거하고 순수 동기(Synchronous) 함수로 변경
- Task.detached 도입: ClusterManager의 격자(Grid) 분할 및 묶음 계산 로직이 메인 스레드를 상속받아 UI를 막지 않도록, Task.detached를 사용해 독립된 글로벌 백그라운드 스레드에서 연산하도록 수정
- 렌더링 일괄 처리: 백그라운드 연산이 모두 끝난 후 완성된 배열을 MainActor.run을 통해 한 번만 UI 스레드에 전달하도록 개선
<br/>

### QuadTree insert 로직 개선
- insert 메서드가 Bool 값을 반환하도록 변경하여 한 노드에 삽입이 성공하면 나머지 노드 탐색을 즉시 종료하도록 최적화
  - QuadTree insert 로직
      1. 내 영역 아니면  바로 종료
      2. 공간 여유 있으면 → 현재 노드에 저장
      3. 꽉 차면 → subdivide
      4. 자식 중 하나에만 삽입 성공하면 종료 -> 해당 로직 개선
  - 결과:  시간 복잡도 개선
  → 탐색 속도 개선
  → O(n) → O(log n)에 가까움
<br/>

- 부모 노드 subdivide 로직 추가 및 개선
  - subdivision 이후에도 부모 노드에 데이터가 남아 탐색 효율이 저하되는 문제
  - 모든 마커 데이터는 트리의 가장 끝단인 단말 노드(Leaf Node)에만 모여 있도록 변경(부모 노드에 있던 8개도 자식 노드로 재분배)하여 탐색 최적화함.
  - 하지만 위 경우 동일 좌표 데이터가 반복 삽입될 경우 무한 재귀가 발생할 수 있는 문제를 확인
          -  위도/경도가 100% 똑같은 마커가 capacity 이상 9개가 들어오면 문제가 발생
          - capacity(8 기준으로) subdivide() 하고 9개를 자식으로 내리는 과정이 무한 루프에 빠짐
  - 최소 영역 크기 제한을 두어 분할을 중단하는 방어 로직을 추가함으로써 안정성과 성능을 함께 개선
          - 최소 격자 크기 제한(약 1m)를 제한을 두어 동일한 위치의 마커 더이상 분할하지 않도록 예외 처리
<br/>

### 지도 카메라 제자리 복귀 현상 수정
- SearchView에서 locationManager.region의 미세한 변화를 .onChange로 감지하여 position을 덮어씌우던 로직 삭제